### PR TITLE
Integrate updater into mod manager

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,14 +1,13 @@
 # Thunderstore package updator
 
 ## Purpose of this script
-This script is used to obtain the latest versions of a Thunderstore package list your povide. 
-It will automatically update the version number in the `packagelist.txt` file you provide and create a new packagelist_updated.txt file with the updated versions from Thunderstore.
+This script obtains the latest versions of a Thunderstore package list you provide.
+It will automatically update the version numbers directly in `package_list.txt`.
 
 ## How to use example
 
 ### arguments
-- `--input_file` default `package_list.txt` : The file that must exist in the same directory as the script. This file should contain the list of packages you want to update.
-- `--output_file` default `package_list_updated.txt` : The file that will be created with the updated versions of the packages.
+- `--input_file` default `package_list.txt` : The file that must exist in the same directory as the script. This file will be overwritten with the updated versions of the packages.
 - `--server_delay` default `1` : The delay between each request to the Thunderstore server. This is to prevent the server from blocking you for making too many requests in a short period of time. Not sure what the limit is, but I would recommend not going below 1 second.
 
 ## Image of the script running

--- a/mod_manager.py
+++ b/mod_manager.py
@@ -2,8 +2,13 @@ import json
 import os
 import subprocess
 import sys
+import time
+from typing import Dict, List
 
-UPDATED_LIST_FILE = "updated_package_list.txt"
+import requests
+from packaging import version
+
+PACKAGE_LIST_FILE = "package_list.txt"
 
 SECTION_TO_FOLDER = {
     "Core": "core",
@@ -15,11 +20,104 @@ SECTION_TO_FOLDER = {
 SECTION_ALIASES = {k.lower(): k for k in SECTION_TO_FOLDER}
 
 
-def parse_updated_package_list(path=UPDATED_LIST_FILE):
+class ThunderStorePackage:
+    def __init__(self, namespace: str, name: str, version_str: str):
+        self.namespace = namespace
+        self.name = name
+        self.version = version_str
+
+    def __repr__(self) -> str:
+        return (
+            f"ThunderStorePackage(namespace={self.namespace}, "
+            f"name={self.name}, version={self.version})"
+        )
+
+
+def parse_package_list_for_update(path: str = PACKAGE_LIST_FILE) -> Dict[str, List[ThunderStorePackage]]:
+    result: Dict[str, List[ThunderStorePackage]] = {k: [] for k in SECTION_TO_FOLDER}
+    current_section = None
+    if not os.path.isfile(path):
+        print(f"Package list not found: {path}")
+        return result
+    with open(path, "r") as f:
+        for raw in f:
+            line = raw.strip()
+            if not line:
+                continue
+            key_lower = line.rstrip(":").lower()
+            if key_lower in SECTION_ALIASES:
+                current_section = SECTION_ALIASES[key_lower]
+                result.setdefault(current_section, [])
+            else:
+                if current_section is None:
+                    continue
+                pkg = line.strip(',').strip('"')
+                if not pkg:
+                    continue
+                parts = pkg.split("-")
+                if len(parts) < 3:
+                    continue
+                namespace, name = parts[0], parts[1]
+                version_str = "-".join(parts[2:])
+                result[current_section].append(
+                    ThunderStorePackage(namespace, name, version_str)
+                )
+    return result
+
+
+def write_packages_to_file(sections_map: Dict[str, List[ThunderStorePackage]], path: str = PACKAGE_LIST_FILE) -> None:
+    with open(path, "w") as file:
+        for section, packages in sections_map.items():
+            file.write(f"{section}\n")
+            for idx, pkg in enumerate(packages):
+                comma = "," if idx < len(packages) - 1 else ""
+                line = (
+                    f"{' ' * 10}\"{pkg.namespace}-{pkg.name}-{pkg.version}\"{comma}"
+                )
+                file.write(line + "\n")
+            file.write("\n\n")
+
+
+def get_thunderstore_package_latest_version(namespace: str, name: str) -> str:
+    url = f"https://thunderstore.io/api/experimental/package/{namespace}/{name}/"
+    response = requests.get(url)
+    if response.status_code == 200:
+        return response.json()["latest"]["version_number"]
+    return "ERROR"
+
+
+def update_package_version(pkg: ThunderStorePackage, delay: int) -> None:
+    pkg.version = get_thunderstore_package_latest_version(pkg.namespace, pkg.name)
+    time.sleep(delay)
+
+
+def print_package_update_status(pkg: ThunderStorePackage, previous_version: str) -> None:
+    if pkg.version != "ERROR":
+        pkg_info = f"{pkg.namespace}-{pkg.name}"
+        if version.parse(pkg.version) > version.parse(previous_version):
+            print(f"{pkg_info:<40} - \u2705 Updated! - {previous_version} -> {pkg.version}")
+        else:
+            print(f"{pkg_info:<40} - {pkg.name} - {pkg.version}")
+    else:
+        print(f"{pkg.namespace} - {pkg.name} - \u274C Error")
+
+
+def update_all_packages(delay: int = 0, path: str = PACKAGE_LIST_FILE) -> None:
+    sections_map = parse_package_list_for_update(path)
+    for section, packages in sections_map.items():
+        print(f"Updating packages in section: {section}")
+        for pkg in packages:
+            prev_version = pkg.version
+            update_package_version(pkg, delay)
+            print_package_update_status(pkg, prev_version)
+    write_packages_to_file(sections_map, path)
+
+
+def parse_updated_package_list(path=PACKAGE_LIST_FILE):
     result = {k: [] for k in SECTION_TO_FOLDER}
     current = None
     if not os.path.isfile(path):
-        print(f"Updated package list not found: {path}")
+        print(f"Package list not found: {path}")
         return result
     with open(path, "r") as f:
         for raw in f:
@@ -59,7 +157,11 @@ def update_dependencies(section_packages):
 
 
 def run_update_mods():
-    subprocess.run([sys.executable, "thunderstore_package_version_updator.py"])
+    try:
+        delay = int(input("Delay between server requests in seconds (0 for none): ").strip() or "0")
+    except ValueError:
+        delay = 0
+    update_all_packages(delay, PACKAGE_LIST_FILE)
 
 
 def distribute_lists():


### PR DESCRIPTION
## Summary
- integrate Thunderstore update logic directly into `mod_manager.py`
- overwrite `package_list.txt` when updating mods
- adjust README for new behaviour

## Testing
- `python -m py_compile mod_manager.py`


------
https://chatgpt.com/codex/tasks/task_e_6855e933cd908333a8f76b3db9e9b2c7