### PR TITLE
Add server delay setting and mod addition option

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ It will automatically update the version numbers directly in `package_list.txt`.
 
 ### arguments
 - `--input_file` default `package_list.txt` : The file that must exist in the same directory as the script. This file will be overwritten with the updated versions of the packages.
-- `--server_delay` default `1` : The delay between each request to the Thunderstore server. This is to prevent the server from blocking you for making too many requests in a short period of time. Not sure what the limit is, but I would recommend not going below 1 second.
+- `--server_delay` default `1` : The delay between each request to the Thunderstore server. This can also be configured through the **Settings** menu. It prevents the server from blocking you for making too many requests in a short period of time. Not sure what the limit is, but I would recommend not going below 1 second.
 
 ## Image of the script running
 ![image](img.png)


### PR DESCRIPTION
## Summary
- allow configuring server delay via settings
- implement an `add_mod` command to append mods to a section
- shorten menu label to **Distribute**
- document the new settings behaviour

## Testing
- `python3 -m py_compile mod_manager.py`
- `python3 mod_manager.py` *(fails: No module named 'requests')*

------
https://chatgpt.com/codex/tasks/task_e_68562c7634cc833386c55a6a8190c13a