### PR TITLE
Refactor upload flow for Thunderstore

### DIFF
--- a/mod_manager.py
+++ b/mod_manager.py
@@ -377,12 +377,31 @@ def upload_packages(token: str, packages_dir: str = "packages") -> None:
             continue
 
         path = os.path.join(packages_dir, name)
+
+        with zipfile.ZipFile(path, "r") as zf:
+            with zf.open("manifest.json") as mf:
+                manifest = json.load(mf)
+            try:
+                with zf.open("README.md") as rf:
+                    readme = rf.read().decode("utf-8")
+            except KeyError:
+                readme = manifest.get("description", "")
+
+        summary = readme.splitlines()[0] if readme else manifest.get("description", "")
+
         metadata = {
             "upload_uuid": str(uuid.uuid4()),
             "author_name": "lethal_coder",
-            "categories": ["Modpacks"],
-            "communities": ["Lethal Company"],
+            "communities": ["lethal-company"],
+            "community_categories": {"lethal-company": ["modpacks"]},
             "has_nsfw_content": False,
+            "package_name": manifest.get("name"),
+            "version_number": manifest.get("version_number"),
+            "platform": "windows",
+            "package_type": "modpack",
+            "package_summary": summary,
+            "package_description": readme,
+            "license": "MIT",
         }
 
         meta_headers = {


### PR DESCRIPTION
## Summary
- refactor `upload_packages` to build full metadata using manifest/README
- send metadata then package bytes to new endpoints

## Testing
- `python -m py_compile mod_manager.py`

------
https://chatgpt.com/codex/tasks/task_e_68563a06342483339dbc52478fbe6802