### PR TITLE
Fix README Unicode handling

### DIFF
--- a/mod_manager.py
+++ b/mod_manager.py
@@ -389,10 +389,10 @@ def update_main_mod_count(mod_count: int) -> None:
 
     readme_path = os.path.join(folder, "README.md")
     if os.path.isfile(readme_path):
-        with open(readme_path, "r") as rf:
+        with open(readme_path, "r", encoding="utf-8") as rf:
             text = rf.read()
         text = text.replace("over 227", f"over {mod_count}")
-        with open(readme_path, "w") as rf:
+        with open(readme_path, "w", encoding="utf-8") as rf:
             rf.write(text)
 
 


### PR DESCRIPTION
## Summary
- update `update_main_mod_count` to read/write `README.md` using UTF-8 encoding

## Testing
- `python -m py_compile mod_manager.py`


------
https://chatgpt.com/codex/tasks/task_e_6856f7ebfb7c833389eb6a65432e9c88