### PR TITLE
Update manifest version handling

### DIFF
--- a/mod_manager.py
+++ b/mod_manager.py
@@ -345,6 +345,14 @@ def settings_menu():
             print("Invalid choice, try again.\n")
 
 
+def replace_version(dep: str, new_version: str) -> str:
+    """Replace the version part of a dependency string if possible."""
+    if dep.count("-") < 2:
+        return dep
+    prefix, _ = dep.rsplit("-", 1)
+    return f"{prefix}-{new_version}"
+
+
 def update_manifest_versions(new_version: str) -> None:
     for folder in SECTION_TO_FOLDER.values():
         manifest_path = os.path.join(folder, "manifest.json")
@@ -358,11 +366,8 @@ def update_manifest_versions(new_version: str) -> None:
         deps = data.get("dependencies", [])
         new_deps = []
         for dep in deps:
-            if dep.lower().startswith(
-                "lethal_coder-lethal_enhanced_party_edition"
-            ):
-                prefix, _ = dep.rsplit("-", 1)
-                new_deps.append(f"{prefix}-{new_version}")
+            if "lethal_enhanced_party_edition" in dep.lower():
+                new_deps.append(replace_version(dep, new_version))
             else:
                 new_deps.append(dep)
         data["dependencies"] = new_deps


### PR DESCRIPTION
## Summary
- add `replace_version` helper to update dependency version segments
- update `update_manifest_versions` to use the helper and detect dependencies containing `Lethal_Enhanced_Party_Edition` case-insensitively

## Testing
- `python -m py_compile mod_manager.py`

------
https://chatgpt.com/codex/tasks/task_e_6856fe5435088333a0a3a61bcc0a3f9c